### PR TITLE
free allocated drmr->request_buf

### DIFF
--- a/drmr.c
+++ b/drmr.c
@@ -431,6 +431,7 @@ static void cleanup(LV2_Handle instance) {
   if (drmr->num_samples > 0)
     free_samples(drmr->samples,drmr->num_samples);
   free(drmr->gains);
+  free(drmr->request_buf);
   free(instance);
 }
 


### PR DESCRIPTION
drmr->request_buf is array of REQ_BUF_SIZE elemens those point to char*. request_buf  is allocated by never freed. This PR fixes it.